### PR TITLE
changed column(1) delimiter to be system-level option

### DIFF
--- a/njb.lua
+++ b/njb.lua
@@ -83,7 +83,7 @@ elseif action == 'list' then
     
     local post_keys = posts.post_order(post_tabs)
     if cfgt.list_with_column then
-        local cold = '\205\173' -- some obscure combining diacritic
+        local cold = cfgt['column_delimiter']
         local cpipe, err = io.popen('column -s ' .. cold .. ' -t', 'w')
         if not cpipe then
             errz.die('Error opening `column` for output: %s', err)
@@ -95,6 +95,7 @@ elseif action == 'list' then
             local chunk = string.format('%s%s%s%s%s\n',
                 k, cold, tstr, cold, p['title'] or ' ')
             cpipe:write(chunk)
+            print(chunk)
         end
         cpipe:close()
     else

--- a/njb_mods/njb_config.lua
+++ b/njb_mods/njb_config.lua
@@ -22,6 +22,10 @@ local cfg_t = {
     -- Whether the utility column(1) should be used to format the output
     -- of njb -l / --list.
     ['list_with_column']     = true,
+    -- Character to use as a column separator when formatting output with
+    -- column(1). Some obscure, stratospheric unicode character is
+    -- recommended, but this may not work on all systems.
+    ['column_delimiter']     = '\205\173',
 }
 
 return cfg_t


### PR DESCRIPTION
Stratospheric unicode code points are the best choice, but don't work on all systems.